### PR TITLE
Adding support for public clients. No client_secret.

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,2 +1,8 @@
 export CREDENTIALS_FIRST_SERVICE=$(jq '.[][0].credentials' <<< $VCAP_SERVICES)
+
+if [ "$ALLOW_PUBLIC" = true ] ; then
+    export CREDENTIALS_FIRST_SERVICE=$(jq 'del(.clientSecret)' <<< $CREDENTIALS_FIRST_SERVICE)
+fi
+
 erb -v /home/vcap/app/public/index.html.erb > /home/vcap/app/public/index.html
+

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ git clone https://github.com/swisscom/sample-uaa-javascript-client.git
 
 Adapt the `manifest.yml` to include the route which you want to assign, the redirect url and the desired scopes. Note that you will also need to reference this route in the service instance creation step below.
 
+ALLOW_PUBLIC: here you can set if the client_secret should be used or not. When ALLOW_PUBLIC is set to true, the client_secret is not used. Corresponds to the UAA allowpublic feature, see https://docs.cloudfoundry.org/api/uaa/version/76.3.0/index.html#authorization-code-grant-2 
+
 ```
 ---
 applications:
@@ -29,6 +31,7 @@ applications:
     env:
       REDIRECT_URI: <your app's route>/callback
       SCOPES: openid, phone
+      ALLOW_PUBLIC: true
 ```
 
 ### Create an instance of the UAA service

--- a/index.html.erb
+++ b/index.html.erb
@@ -89,14 +89,19 @@ if(q.code) {
     } else {
 
         // Exchange the authorization code for an access token
-        sendPostRequest(config.service_credentials.tokenEndpoint, {
+        var param = {
             grant_type: "authorization_code",
             code: q.code,
             client_id: config.service_credentials.clientId,
             client_secret: config.service_credentials.clientSecret,
             redirect_uri: config.redirect_uri,
             code_verifier: localStorage.getItem("pkce_code_verifier")
-        }, function(request, bodyPost) {
+        };
+        if (typeof config.service_credentials.clientSecret === 'undefined') {
+          delete param["client_secret"];
+        }
+        sendPostRequest(config.service_credentials.tokenEndpoint, param
+        , function(request, bodyPost) {
 
             sendGetRequest(config.service_credentials.userInfoEndpoint, bodyPost.access_token,
                 function(request, bodyGet) {


### PR DESCRIPTION
Adds support to handle both, public or confidential clients for the authorization_code grant type flow. 
With a public single page application (SPA) no client_secret should be provided for the oauth/token request. 
The code change includes a switch to set ALLOW_PUBLIC (ENV) in case the client still provides a client_secret from VCAP_SERVICES (check on .profile - delete clientSecret property). As soon we will create a "public" client without a client_secret provided on VCAP_SERVICES this environment setting is not necessary any longer. 
If no clientSecret property is set (undefined) we then finally remove these parameter for the token POST request.

For a confidential client the client_secret is provided on VCAP_SERVICES and we use it for the token request.
    